### PR TITLE
esx_multicharacter string replace / fivem-appearance swap

### DIFF
--- a/ox_basic.yaml
+++ b/ox_basic.yaml
@@ -64,14 +64,9 @@ tasks:
     ref: master
     dest: ./resources/[esx]/esx_multicharacter
 
-  - action: replace_string
-    file: ./resources/[esx]/esx_multicharacter/server/main.lua
-    search: "Config.Database = 'es_extended'"
-    replace: "Config.Database = '{{dbName}}'"
-
   ## Download fivem-appearance
   - action: download_github
-    src: https://github.com/ZiggyJoJo/brp-fivem-appearance
+    src: https://github.com/overextended/fivem-appearance
     ref: main
     dest: ./resources/fivem-appearance
 


### PR DESCRIPTION
replace_string not needed as config.database is not in main.lua
swap ziggy fivem-appearance for overextended lua version