### PR TITLE
Update recipe.yaml

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -212,9 +212,9 @@ tasks:
 
   ## screenshot-basic
   - action: download_github
-    src: https://github.com/project-error/screenshot-basic
+    src: https://github.com/citizenfx/screenshot-basic
     ref: master
-    dest: ./resources/[pe]/screenshot-basic
+    dest: ./resources/screenshot-basic
 
   ## loadingscreen
   - action: download_github


### PR DESCRIPTION
NPWD no longer uses their own fork of screenshot-basic and has reverted to using the cfx version. 

From Discord: "Sorry for the @everyone , but important notice which I forgot to mention. We have moved image uploading in NPWD to the server side, which means you need to replace your current screenshot-basic resource with the one from cfx => https://github.com/citizenfx/screenshot-basic. (1.5.5 and higher) Sorry for the inconvenience"