### PR TITLE
chore: bump minimum artifacts version & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # ox_core recipe
 
 Recipe for deploying a basic ox_core server through [txAdmin](https://github.com/tabarra/txAdmin).  
-This recipe is a work in progress, as are many of the resources packaged with it; parts are __definitely__ broken.
-
-Feel free to report issues but do not expect any support at this stage, this is not production ready by any means.
+All of the resources included have been tested and are **mostly working** with minimal bugs.
+Feel free to report issues with this recipe if you encounter any.
 
 __**This recipe is provided as a courtesey and is not recommended.**__  
 Manually setting up your server with git allows for version control and merging changes.

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,5 +1,5 @@
 $engine: 3
-$minFxVersion: 7290
+$minFxVersion: 12913
 $onesync: on
 name: ox_core
 version: 1.0.0


### PR DESCRIPTION
Pretty simple - oxmysql and ox_core now require FXServer `12913`, the recipe has been updated as such.
README has also been updated to show that ox_core and other included resources are now stable.